### PR TITLE
Print Symbols stored in database

### DIFF
--- a/src/components/Library/Library.js
+++ b/src/components/Library/Library.js
@@ -129,10 +129,20 @@ class Library extends Component {
             var pos = note.position; //array of coordinates [row, column, index]
             var data = note.number;
             if(note.dot === "TOP") { doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (50+(pos[0]*25)), .7, .7, 'F'); }
-            if(note.doubleDot === "TOP") { doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (48+(pos[0]*25)), .7, .7, 'F'); }
             if(note.dot === "BOTTOM") { doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (62+(pos[0]*25)), .7, .7, "F"); }
-            if(note.doubleDot === )
-doc.ellipse(25, 64, .7, .7, "F")
+            if(note.doubleDot === "TOP") { 
+                doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (48+(pos[0]*25)), .7, .7, 'F'); 
+                doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (50+(pos[0]*25)), .7, .7, 'F'); 
+            }
+            if(note.doubleDot === "BOTTOM") { 
+                doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (64+(pos[0]*25)), .7, .7, "F");
+                doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (62+(pos[0]*25)), .7, .7, "F");
+            }
+            if(note.line === true) { doc.line( (21+(pos[1]*40)+(pos[2]*10)), (59+(pos[0]*25)), (31+(pos[1]*40)+(pos[2]*10)),(59+(pos[0]*25)) ); }
+            if(note.doubleLine === true) { 
+                doc.line( (21+(pos[1]*40)+(pos[2]*10)), (60+(pos[0]*25)), (31+(pos[1]*40)+(pos[2]*10)),(60+(pos[0]*25)) );
+                doc.line( (21+(pos[1]*40)+(pos[2]*10)), (59+(pos[0]*25)), (31+(pos[1]*40)+(pos[2]*10)),(59+(pos[0]*25)) );
+            }
             doc.text( (23+(pos[1]*40)+(pos[2]*10)),  (58+(pos[0]*25)), data.toString());
             addLineBars(pos[0]);
         });

--- a/src/components/Library/Library.js
+++ b/src/components/Library/Library.js
@@ -128,6 +128,11 @@ class Library extends Component {
         this.state.notes.forEach((note) => {
             var pos = note.position; //array of coordinates [row, column, index]
             var data = note.number;
+            if(note.dot === "TOP") { doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (50+(pos[0]*25)), .7, .7, 'F'); }
+            if(note.doubleDot === "TOP") { doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (48+(pos[0]*25)), .7, .7, 'F'); }
+            if(note.dot === "BOTTOM") { doc.ellipse( (25+(pos[1]*40)+(pos[2]*10)), (62+(pos[0]*25)), .7, .7, "F"); }
+            if(note.doubleDot === )
+doc.ellipse(25, 64, .7, .7, "F")
             doc.text( (23+(pos[1]*40)+(pos[2]*10)),  (58+(pos[0]*25)), data.toString());
             addLineBars(pos[0]);
         });


### PR DESCRIPTION
Now notes are read for symbols so they can be viewed when the pdf is generated. 
Supports:
* underline, double underline
* top and bottom dots, and double dots